### PR TITLE
Admin Mapping: Grouped Reports Integration, Cluster Visuals, UX Polish, and Legends

### DIFF
--- a/src/components/Admin/ClusterDetailsModal.jsx
+++ b/src/components/Admin/ClusterDetailsModal.jsx
@@ -161,6 +161,9 @@ const ClusterDetailsModal = ({
       if (typeof refetchSpecificCluster === "function") {
         refetchSpecificCluster();
       }
+      if (typeof refetchGroupedReports === "function") {
+        refetchGroupedReports();
+      }
     } catch (error) {
       console.error("[Cluster] Failed to remove report from cluster:", error);
       const msg =
@@ -269,6 +272,7 @@ const ClusterDetailsModal = ({
 
   // Precompute IDs eligible for resolve-all (exclude removed & validated sub-cluster)
   const resolveAllIds = Array.from(selectableReportIds);
+  const isClusterTooSmall = resolveAllIds.length <= 1 && !isClusterResolved;
 
   return (
     <dialog
@@ -338,6 +342,13 @@ const ClusterDetailsModal = ({
                   </p>
                 </div>
               </div>
+            ) : isClusterTooSmall ? (
+              <div className="w-full">
+                <div className="px-4 py-3 rounded-lg border border-gray-200 bg-gray-50 text-gray-700 text-sm">
+                  This cluster now contains only one report and is no longer
+                  considered a cluster. No further actions are available here.
+                </div>
+              </div>
             ) : !hasResolvedReports() ? (
               <div className="flex gap-2">
                 <button
@@ -363,26 +374,9 @@ const ClusterDetailsModal = ({
                   </button>
                 )}
                 {resolveAllIds.length === 1 && (
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <span>
-                      Only 1 report remaining - cannot form sub-cluster
-                    </span>
-                    <button
-                      onClick={() => {
-                        confirmRemoveFromCluster(resolveAllIds[0]);
-                      }}
-                      className="btn btn-error btn-sm"
-                      disabled={removingId === resolveAllIds[0]}
-                    >
-                      {removingId === resolveAllIds[0] ? (
-                        <>
-                          <span className="loading loading-spinner loading-sm"></span>
-                          Removing...
-                        </>
-                      ) : (
-                        "Remove Report"
-                      )}
-                    </button>
+                  <div className="w-full px-4 py-3 rounded-lg border border-gray-200 bg-gray-50 text-gray-700 text-sm">
+                    This cluster now contains only one report and is no longer
+                    considered a cluster.
                   </div>
                 )}
                 {/* Reject All removed per updated flow */}
@@ -562,7 +556,7 @@ const ClusterDetailsModal = ({
 
                         {/* Action Buttons */}
                         <div className="flex gap-2 flex-wrap">
-                          {!isRemoved && (
+                          {!isRemoved && !isClusterTooSmall && (
                             <>
                               {!rejectedReports.includes(reportId) && (
                                 <>
@@ -675,6 +669,12 @@ const ClusterDetailsModal = ({
 
                               {/* Unreject removed per updated design */}
                             </>
+                          )}
+                          {isClusterTooSmall && (
+                            <div className="text-sm text-gray-600">
+                              Actions have been disabled because this is no
+                              longer a cluster.
+                            </div>
                           )}
 
                           <button

--- a/src/components/Admin/ClusterDropdown.jsx
+++ b/src/components/Admin/ClusterDropdown.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Megaphone, CaretDown } from "phosphor-react";
+import { CaretDown } from "phosphor-react";
 
 const ClusterDropdown = ({
   showClusterDropdown,
@@ -21,10 +21,13 @@ const ClusterDropdown = ({
       <button
         type="button"
         onClick={() => setShowClusterDropdown((s) => !s)}
-        className="flex items-center gap-2 bg-error text-white font-bold border border-error py-2 pl-3 pr-2 text-sm rounded-full shadow hover:brightness-95 active:brightness-90 transition"
+        className={`flex items-center gap-2 font-bold py-2 pl-3 pr-2 text-sm rounded-full shadow hover:brightness-95 active:brightness-90 transition ${
+          pendingClusters.length + partiallyResolvedClusters.length > 0
+            ? "bg-error text-white border border-error"
+            : "bg-white text-primary border border-gray-300"
+        }`}
         disabled={isLoadingClusters}
       >
-        <Megaphone weight="fill" />
         {isLoadingClusters ? (
           <span className="flex items-center gap-2">
             <span className="loading loading-spinner loading-xs"></span>

--- a/src/components/Admin/MapContainer.jsx
+++ b/src/components/Admin/MapContainer.jsx
@@ -12,6 +12,7 @@ const MapContainer = ({
   setSelectedFullReport,
   setShowFullReport,
   clusters = [],
+  baseUrl = "/mapping",
 }) => {
   return (
     <div className="flex h-[50vh] mb-4" ref={mapContainerRef}>
@@ -25,6 +26,7 @@ const MapContainer = ({
         clusters={clusters}
         style={{ height: "100%", width: "100%" }}
         useAdminEndpoint={true}
+        baseUrl={baseUrl}
         onMarkerClick={(item, type) => {
           if (type === "report") {
             setSelectedFullReport(item);

--- a/src/components/Mapping/MapOnly.jsx
+++ b/src/components/Mapping/MapOnly.jsx
@@ -85,6 +85,7 @@ const MapOnly = forwardRef(
       recentOnly = false, // Show only recent validated reports markers
       recentCount = 5, // How many recent markers to show when recentOnly is true
       recentPosts = null, // Optional: provide the same recent posts as table
+      baseUrl = "/mapping",
     },
     ref
   ) => {
@@ -107,6 +108,28 @@ const MapOnly = forwardRef(
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
     const mapId = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID;
     const [infoWindow, setInfoWindow] = useState(null);
+    const effectiveBaseUrl = useRef(null);
+    if (effectiveBaseUrl.current === null) {
+      if (baseUrl && typeof baseUrl === "string" && baseUrl.length > 0) {
+        effectiveBaseUrl.current = baseUrl;
+      } else {
+        const path =
+          typeof window !== "undefined" ? window.location.pathname : "";
+        effectiveBaseUrl.current = path.includes("/admin")
+          ? "/admin/mapping"
+          : "/mapping";
+      }
+      try {
+        console.debug("[MapOnly] Base URL debug", {
+          propBaseUrl: baseUrl,
+          effectiveBaseUrl: effectiveBaseUrl.current,
+          locationPath:
+            typeof window !== "undefined"
+              ? window.location.pathname
+              : "(no-window)",
+        });
+      } catch (_) {}
+    }
     const clusterOverlaysRef = useRef([]);
     const breedingMarkersRef = useRef([]);
 
@@ -564,11 +587,72 @@ const MapOnly = forwardRef(
                       : ""
                   }
                 </div>
-                <button class=\"mt-4 px-4 py-2 bg-primary w-[40%] text-white rounded-lg shadow hover:bg-primary/80 hover:cursor-pointer font-bold\" onclick=\"window.location.href='/mapping/${
+                <button data-report-id=\"${
                   site._id
-                }'\">View Details</button>
+                }\" id=\"bm-view-details-btn\" class=\"mt-4 px-4 py-2 bg-primary w-[40%] text-white rounded-lg shadow hover:bg-primary/80 hover:cursor-pointer font-bold\">View Details</button>
               </div>
             `;
+
+                try {
+                  console.debug("[MapOnly] InfoWindow open", {
+                    reportId: site._id,
+                    isClusterMember,
+                    status: site.status,
+                    propBaseUrl: baseUrl,
+                    effectiveBaseUrl: effectiveBaseUrl.current,
+                    locationPath:
+                      typeof window !== "undefined"
+                        ? window.location.pathname
+                        : "(no-window)",
+                  });
+                } catch (_) {}
+
+                // Attach explicit button click handler with robust base URL choice
+                try {
+                  const btn = content.querySelector("#bm-view-details-btn");
+                  if (btn) {
+                    btn.addEventListener("click", () => {
+                      try {
+                        const reportId = String(site._id || "");
+                        const path =
+                          window && window.location && window.location.pathname
+                            ? window.location.pathname
+                            : "";
+                        const derived =
+                          path.indexOf("/admin") > -1
+                            ? "/admin/mapping"
+                            : "/mapping";
+                        const finalBase =
+                          effectiveBaseUrl.current &&
+                          typeof effectiveBaseUrl.current === "string" &&
+                          effectiveBaseUrl.current.length > 0
+                            ? effectiveBaseUrl.current
+                            : baseUrl &&
+                              typeof baseUrl === "string" &&
+                              baseUrl.length > 0
+                            ? baseUrl
+                            : derived;
+                        console.debug("[MapOnly] Navigate click (listener)", {
+                          reportId,
+                          path,
+                          derived,
+                          baseProp: baseUrl,
+                          effectiveBase: effectiveBaseUrl.current,
+                          finalBase,
+                        });
+                        window.location.href = `${finalBase}/${reportId}`;
+                      } catch (e) {
+                        console.error(
+                          "[MapOnly] Navigate click error (listener)",
+                          e
+                        );
+                        window.location.href = `/mapping/${site._id}`;
+                      }
+                    });
+                  }
+                } catch (e) {
+                  console.error("[MapOnly] Failed to bind click listener", e);
+                }
 
                 infoWindow.setContent(content);
                 infoWindow.setPosition({
@@ -874,11 +958,12 @@ const MapOnly = forwardRef(
           // Toggle visibility based on zoom: always show circles; toggle report markers
           const updateVisibility = () => {
             try {
-              const showMarkers = true; // Always show individual report markers at all zoom levels
-              breedingMarkersRef.current.forEach((m) => m.setMap(map));
-              // Keep cluster overlays visible as well
+              const visibleMap = showBreedingSites ? map : null;
+              // Show/hide individual report markers based on toggle
+              breedingMarkersRef.current.forEach((m) => m.setMap(visibleMap));
+              // Show/hide cluster overlays based on toggle
               clusterOverlaysRef.current.forEach(
-                (o) => o.setMap && o.setMap(map)
+                (o) => o.setMap && o.setMap(visibleMap)
               );
             } catch (_) {}
           };
@@ -913,6 +998,18 @@ const MapOnly = forwardRef(
       onBarangaySelect,
       clusters,
     ]);
+
+    // React to Breeding Sites toggle without redrawing map
+    useEffect(() => {
+      const map = mapInstance.current;
+      const visibleMap = showBreedingSites ? map : null;
+      try {
+        breedingMarkersRef.current.forEach((m) => m.setMap(visibleMap));
+        clusterOverlaysRef.current.forEach(
+          (o) => o.setMap && o.setMap(visibleMap)
+        );
+      } catch (_) {}
+    }, [showBreedingSites]);
 
     // Add this effect to initialize the info window
     useEffect(() => {

--- a/src/pages/admin/DengueMapping.jsx
+++ b/src/pages/admin/DengueMapping.jsx
@@ -138,6 +138,17 @@ const DengueMapping = () => {
   const [validatePost] = useValidatePostMutation();
 
   const [recentDengueCases, setRecentDengueCases] = useState(null);
+  // Debug: confirm we're in Admin DengueMapping and using admin baseUrl
+  useEffect(() => {
+    try {
+      console.debug("[Admin/DengueMapping] Mounted", {
+        locationPath:
+          typeof window !== "undefined"
+            ? window.location.pathname
+            : "(no-window)",
+      });
+    } catch (_) {}
+  }, []);
 
   // Get clusters from API
   const { data: clustersData, isLoading: isLoadingClusters } =

--- a/src/pages/admin/DengueMapping.jsx
+++ b/src/pages/admin/DengueMapping.jsx
@@ -1398,6 +1398,53 @@ const DengueMapping = () => {
                           />
                           <span>Others</span>
                         </div>
+                        {/* Cluster-specific legends */}
+                        <div className="mt-2 pt-2 border-t border-gray-200" />
+                        <div className="flex items-center gap-2">
+                          {/* Violet marker chip to indicate cluster member */}
+                          <span
+                            className="inline-block w-3 h-3 rounded-full"
+                            style={{ backgroundColor: "#8B5CF6" }}
+                            aria-hidden
+                          />
+                          <span>Cluster Member Marker</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {/* Orange small dot for pending badge */}
+                          <span className="relative inline-flex items-center">
+                            <span
+                              className="inline-block w-3 h-3 rounded-full bg-white border"
+                              aria-hidden
+                            />
+                            <span
+                              className="inline-block w-2 h-2 rounded-full absolute -top-1 -right-1"
+                              style={{
+                                backgroundColor: "#f59e0b",
+                                border: "1px solid #fff",
+                              }}
+                              aria-hidden
+                            />
+                          </span>
+                          <span>Pending Status Indicator</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {/* Red circle swatch for active cluster circle */}
+                          <span
+                            className="inline-block w-3 h-3 rounded-full bg-white"
+                            style={{ border: "2px solid #dc2626" }}
+                            aria-hidden
+                          />
+                          <span>Cluster Area — Unchecked</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {/* Green circle swatch for resolved cluster circle */}
+                          <span
+                            className="inline-block w-3 h-3 rounded-full bg-white"
+                            style={{ border: "2px solid #10b981" }}
+                            aria-hidden
+                          />
+                          <span>Cluster Area — Resolved</span>
+                        </div>
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
## Admin Mapping: Grouped Reports Integration, Cluster Visuals, UX Polish, and Legends

### Overview

This document describes the updates made to the admin mapping experience, including switching to the grouped reports API, improving cluster/marker visuals, polishing the cluster details workflow, fixing routing, and adding appropriate legends.

### Data & Integration

- Use grouped endpoint for mapping data: `GET reports/grouped`
- Add RTK Query endpoint `getGroupedReports` and hook `useGetGroupedReportsQuery`
- Rendering behavior:
  - Individual markers come from `individual_reports`
  - Cluster member markers come from `clusters[].reports`

### Marker and Cluster Visuals

- Individual report markers are always visible at all zoom levels
- Cluster member markers are violet; pending status shows a small orange dot on the pin
- Cluster areas are circles:
  - Green border when resolved
  - Red border when unresolved
  - Circle center is computed from member coordinates when not provided by backend

### Map Legend Additions (Admin Mapping)

Legend now includes items for the new visuals under Breeding Sites:

- Violet Cluster Member Marker
- Orange Pending Status Indicator (small dot)
- Cluster Area — Unchecked (red border-only swatch)
- Cluster Area — Resolved (green border-only swatch)

### UX Improvements

- Hide Breeding Sites toggle now hides both individual markers and cluster circles
- ClusterDetailsModal:
  - When only one report remains, display a neutral notice: “This cluster now contains only one report and is no longer considered a cluster. No further actions are available here.”
  - Disable action buttons in this state and remove the confusing single-report Remove button
  - After removing or resolving, refetch clustered/individual data to keep the admin map in sync

### Routing Fix

- InfoWindow “View Details” button now navigates to the admin path `/admin/mapping/<id>`
- Includes a robust base URL fallback:
  - Prefer provided `baseUrl` prop
  - Otherwise derive from current path (`/admin/mapping` vs `/mapping`)

### Cluster Dropdown Polish

- Remove megaphone icon
- Use a neutral button (white background, primary text, gray border) when there are no active clusters
- Keep red styling only when active clusters exist

### Rationale

These changes remove ambiguity between cluster and individual markers by using the backend’s grouped source of truth, improve readability with clear color semantics and legends, prevent invalid actions when a cluster is too small, and fix admin navigation.

### Testing Guidelines

1. Admin Mapping (/admin/denguemapping)
   - Verify individual markers (orange) are visible at all zooms
   - Confirm violet cluster member markers and orange pending dots
   - Confirm cluster circles: red border (unchecked) vs green border (resolved)
   - Toggle Hide Breeding Sites; both markers and circles should hide/show
2. ClusterDetailsModal
   - Remove reports until one remains: neutral notice shown, actions disabled, no extra remove button
   - After resolve/remove, confirm the map refreshes
3. InfoWindow
   - View Details routes to `/admin/mapping/<id>`
4. ClusterDropdown
   - No active clusters: neutral button
   - Active clusters: red styling

### Notes

- Backend grouped route reference: `reports/grouped` with arrays `individual_reports` and `clusters`
- No migrations or environment changes are required
