### PR TITLE
feat(analytics): keep controls visible and show friendly no-data state

### DIFF
--- a/src/components/Admin/DengueChartCard.jsx
+++ b/src/components/Admin/DengueChartCard.jsx
@@ -65,6 +65,30 @@ export default function DengueChartCard() {
     number_of_weeks: weeks,
   });
 
+  // Friendly handling for not-found/404
+  const barangayNotFound = useMemo(() => {
+    const apiFlag =
+      trendsData &&
+      trendsData.success === false &&
+      (trendsData.error === "Barangay not found in dataset" ||
+        (typeof trendsData.error === "string" &&
+          trendsData.error.toLowerCase().includes("barangay not found")));
+    const errData = error && error.data ? error.data : {};
+    const errMsg = (
+      (errData.error || errData.message || error?.error || "") + ""
+    ).toLowerCase();
+    return Boolean(apiFlag || errMsg.includes("barangay not found"));
+  }, [trendsData, error]);
+
+  const httpNotFound = useMemo(() => {
+    const statuses = [
+      error?.status,
+      error?.originalStatus,
+      error?.data?.status,
+    ];
+    return statuses?.some?.((s) => s === 404) || false;
+  }, [error]);
+
   // Get color based on pattern using centralized configuration
   const lineColor = getPatternColor(selectedBarangayPattern, "stroke");
 
@@ -144,15 +168,13 @@ export default function DengueChartCard() {
     return weekEntries;
   }, [trendsData]);
 
-  const chartLabels = chartData.map((d) => d.week);
-  const chartCases = chartData.map((d) => d.cases);
+  const chartCases = chartData.map((d) => d.cases ?? 0);
+  const hasAnyData = chartData.length > 0 && chartCases.some((c) => c > 0);
 
   // Find the max cases for the current chartData (for consistent Y axis)
-  const maxCases = chartCases.length > 0 ? Math.max(5, ...chartCases) : 10;
+  const maxCases = hasAnyData ? Math.max(5, ...chartCases) : 10;
 
-  console.log("Transformed Chart Data:", chartData);
-
-  if (isLoading) {
+  if (isLoading || barangaysLoading) {
     return (
       <div className="w-full bg-primary p-6 rounded-sm flex items-center justify-center">
         <span className="loading loading-spinner loading-lg text-white"></span>
@@ -160,18 +182,11 @@ export default function DengueChartCard() {
     );
   }
 
-  if (error) {
-    return (
-      <div className="w-full bg-primary p-6 rounded-sm flex items-center justify-center">
-        <p className="text-white">Error loading chart data</p>
-      </div>
-    );
-  }
-
-  // Do not early-return on empty data; keep UI usable and show toast instead
+  // Do not early-return on error; show empty container with message
+  const showNoData = barangayNotFound || httpNotFound || !hasAnyData;
 
   return (
-    <div className="w-full bg-primary p-6 rounded-sm">
+    <div className="w-full bg-primary p-6 rounded-sm relative">
       <div className="flex justify-between items-center mb-4">
         <div>
           <p className="text-2xl text-center font-semibold text-white">
@@ -224,11 +239,11 @@ export default function DengueChartCard() {
           </select>
         </div>
       </div>
-      {(chartData?.length ?? 0) === 0 ? (
+
+      {showNoData ? (
         <div className="w-full h-[200px] bg-primary/60 rounded-sm flex items-center justify-center">
-          <p className="text-white/80">
-            No chart data available for {selectedBarangay} with the selected
-            week range.
+          <p className="text-white/80 text-sm">
+            There has been no recorded dengue cases for {selectedBarangay}.
           </p>
         </div>
       ) : (
@@ -270,12 +285,7 @@ export default function DengueChartCard() {
               dataKey="cases"
               stroke={lineColor}
               strokeWidth={3}
-              dot={{
-                r: 5,
-                stroke: lineColor,
-                strokeWidth: 2,
-                fill: lineColor,
-              }}
+              dot={{ r: 5, stroke: lineColor, strokeWidth: 2, fill: lineColor }}
               activeDot={{
                 r: 7,
                 stroke: lineColor,

--- a/src/components/Admin/DengueTrendChart.jsx
+++ b/src/components/Admin/DengueTrendChart.jsx
@@ -105,6 +105,33 @@ export default function DengueTrendChart({
     { skip: skipTrends }
   );
 
+  // Detect the specific not-found condition coming from the API
+  const barangayNotFound = useMemo(() => {
+    const apiFlag =
+      trendsData &&
+      trendsData.success === false &&
+      (trendsData.error === "Barangay not found in dataset" ||
+        (typeof trendsData.error === "string" &&
+          trendsData.error.toLowerCase().includes("barangay not found")));
+    const errData = error && error.data ? error.data : {};
+    const errMsg =
+      (errData.error || errData.message || error?.error || "") + "";
+    const errFlag = errMsg.toLowerCase().includes("barangay not found");
+    return Boolean(apiFlag || errFlag);
+  }, [trendsData, error]);
+
+  // Treat HTTP 404 as a not-found dataset state as well
+  const httpNotFound = useMemo(() => {
+    const statuses = [
+      error?.status,
+      error?.originalStatus,
+      error?.data?.status,
+    ];
+    return statuses.includes && statuses.includes(404)
+      ? true
+      : statuses.some?.((s) => s === 404);
+  }, [error]);
+
   // Transform the API data to match the chart format
   const chartData = useMemo(() => {
     try {
@@ -230,6 +257,14 @@ export default function DengueTrendChart({
     return ticks;
   }, [maxCases]);
 
+  // Extra diagnostics for visibility
+  if (error) {
+    console.log("[DengueTrendChart] Raw error object:", error);
+  }
+  if (trendsData !== undefined) {
+    console.log("[DengueTrendChart] Raw trendsData:", trendsData);
+  }
+
   if (isLoading || barangaysLoading) {
     return (
       <div className="flex flex-col p-5 gap-4 items-center justify-center h-[400px]">
@@ -238,73 +273,16 @@ export default function DengueTrendChart({
     );
   }
 
-  if (error) {
-    console.error("[DEBUG] Chart error:", error);
-    return (
-      <div className="flex flex-col p-5 gap-4 items-center  h-full justify-center text-center">
-        {isFetching ? (
-          <span className="loading loading-spinner loading-lg text-primary" />
-        ) : refreshNum <= 1 ? (
-          <>
-            <p className="text-gray-700 text-lg">
-              Hmmm... we couldn't load the chart data.
-              <br />
-              Try refreshing it below.
-            </p>
-            <button
-              onClick={() => {
-                refetch();
-                console.log(refreshNum);
-                setRefreshNum((currentNum) => currentNum + 1);
-              }}
-              disabled={isFetching}
-              className="btn text-primary px-4 py-2 rounded  transition"
-            >
-              {isFetching ? (
-                "Refreshing..."
-              ) : (
-                <div className="flex justify-between gap-1  items-center">
-                  <p>Refresh Chart</p>
-                  <IconReload size={12} />
-                </div>
-              )}
-            </button>
-          </>
-        ) : (
-          <p className="text-red-500 text-lg">
-            Something went wrong with the chart.
-            <br />
-            Please try again later.
-          </p>
-        )}
-      </div>
-    );
-  }
-
-  if (!selectedBarangay) {
-    return (
-      <div className="flex flex-col p-5 gap-4">
-        <p className="text-warning">Please select a barangay to view trends.</p>
-      </div>
-    );
-  }
-
-  if (!chartData || chartData.length === 0) {
-    return (
-      <div className="flex flex-col p-5 gap-4">
-        <p className="text-warning">
-          No data available for the selected period
-        </p>
-      </div>
-    );
-  }
+  // Always render header & selectors
+  const showNoData =
+    barangayNotFound || httpNotFound || !chartData || chartData.length === 0;
 
   return (
     <div className="flex flex-col p-5 gap-4">
       <div className="flex justify-between items-center">
         <div>
           <p className="text-base-content text-xl font-semibold mb-1">
-            Dengue Cases Trend - {selectedBarangay}
+            Dengue Cases Trend - {selectedBarangay || "—"}
           </p>
           <p className="text-base-content text-sm">
             Pattern:{" "}
@@ -332,9 +310,9 @@ export default function DengueTrendChart({
             {barangaysLoading ? (
               <option>Loading barangays...</option>
             ) : barangaysData ? (
-              barangaysData.map((barangay) => (
-                <option key={barangay._id} value={barangay.name}>
-                  {barangay.name}
+              barangaysData.map((b) => (
+                <option key={b._id} value={b.name}>
+                  {b.name}
                 </option>
               ))
             ) : (
@@ -371,138 +349,72 @@ export default function DengueTrendChart({
           </select>
         </div>
       </div>
-      <ChartContainer className="h-full w-full flex flex-col gap-2">
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart
-            data={chartData}
-            margin={{ left: -38, top: 10, right: 4, bottom: 5 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" vertical={false} />
-            <XAxis
-              dataKey="week"
-              tick={{ fontSize: 11, fontFamily: "Inter", fill: "#000000" }}
-            />
-            <YAxis
-              tick={{ fontSize: 11, fontFamily: "Inter", fill: "#000000" }}
-            />
-            <Tooltip />
-            <Legend
-              formatter={(value) => "Number of Cases"}
-              wrapperStyle={{
-                color: "#000000",
-                fontSize: "14px",
-                marginLeft: "45px",
-                marginBottom: "-2px",
-              }}
-              align="left"
-            />
-            <ReferenceLine
-              x={referenceLinePosition}
-              stroke="#9ca3af"
-              strokeDasharray="5 5"
-              strokeWidth={1}
-              segment={[
-                { x: referenceLinePosition, y: 0 },
-                { x: chartData[chartData.length - 1]?.week, y: 0 },
-              ]}
-              label={({ viewBox }) => {
-                const { x, y } = viewBox;
-                return (
-                  <g transform={`translate(${x},${y + 100})`}>
-                    <rect
-                      x={-60}
-                      y={-10}
-                      width={120}
-                      height={20}
-                      fill="oklch(0.98 0.0035 219.53)"
-                      rx={4}
-                    />
-                    <text
-                      x={0}
-                      y={2}
-                      textAnchor="middle"
-                      dominantBaseline="middle"
-                      fill="#9ca3af"
-                      fontSize={11}
-                      fontWeight={500}
-                    >
-                      Assessment Period
-                    </text>
-                  </g>
-                );
-              }}
-            />
-            <Tooltip
-              content={({ active, payload }) => {
-                if (active && payload && payload.length > 0) {
-                  const dataPoint = payload[0].payload;
-                  if (
-                    dataPoint.week === chartData[chartData.length - 4]?.week
-                  ) {
-                    return (
-                      <div className="bg-white p-2 border border-gray-200 rounded shadow-sm">
-                        <p className="text-sm text-gray-700">
-                          Start of {selectedBarangayPattern || "pattern"}
-                        </p>
-                      </div>
-                    );
-                  }
-                }
-                return null;
-              }}
-            />
-            <Line
-              type="monotone"
-              dataKey="cases"
-              stroke={getPatternColorForChart(selectedBarangayPattern)}
-              strokeWidth={3}
-              dot={{
-                r: 5,
-                strokeWidth: 2,
-                fill: getPatternColorForChart(selectedBarangayPattern),
-                stroke: getPatternColorForChart(selectedBarangayPattern),
-              }}
-              activeDot={{
-                r: 7,
-                strokeWidth: 2,
-                fill: getPatternColorForChart(selectedBarangayPattern),
-                stroke: getPatternColorForChart(selectedBarangayPattern),
-              }}
-              label={({ x, y, value }) => (
-                <text
-                  x={x}
-                  y={y}
-                  dy={-10}
-                  fill="#444444"
-                  textAnchor="middle"
-                  fontSize={10}
-                  fontFamily="Inter"
-                  fontWeight="500"
-                >
-                  {value}
-                </text>
+
+      <ChartContainer className="h-full w-full flex flex-col gap-2 relative">
+        {showNoData ? (
+          <div className="w-full h-[400px] rounded border border-gray-200 bg-white flex items-center justify-center">
+            <p className="text-gray-700 text-sm">
+              There has been no recorded dengue cases for{" "}
+              {selectedBarangay || "this barangay"}.
+            </p>
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={400}>
+            <LineChart
+              data={chartData}
+              margin={{ left: -38, top: 10, right: 4, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis
+                dataKey="week"
+                tick={{ fontSize: 11, fontFamily: "Inter", fill: "#000000" }}
+              />
+              <YAxis
+                tick={{ fontSize: 11, fontFamily: "Inter", fill: "#000000" }}
+              />
+              <Tooltip />
+              <Legend
+                formatter={() => "Number of Cases"}
+                wrapperStyle={{
+                  color: "#000000",
+                  fontSize: "14px",
+                  marginLeft: "45px",
+                  marginBottom: "-2px",
+                }}
+                align="left"
+              />
+              {referenceLinePosition && (
+                <ReferenceLine
+                  x={referenceLinePosition}
+                  stroke="#9ca3af"
+                  strokeDasharray="5 5"
+                  strokeWidth={1}
+                />
               )}
-            />
-            {selectedBarangay && patternData && (
-              <ReferenceLine
-                x={patternData.start_date}
-                stroke={getPatternColorForChart(patternData.pattern)}
-                strokeWidth={2}
-                label={{
-                  value: formatPatternType(patternData.pattern),
-                  position: "insideTopRight",
-                  fill: getPatternColorForChart(patternData.pattern),
-                  fontSize: 12,
-                  fontWeight: "bold",
+              <Line
+                type="monotone"
+                dataKey="cases"
+                stroke={getPatternColorForChart(selectedBarangayPattern)}
+                strokeWidth={3}
+                dot={{
+                  r: 5,
+                  strokeWidth: 2,
+                  fill: getPatternColorForChart(selectedBarangayPattern),
+                  stroke: getPatternColorForChart(selectedBarangayPattern),
+                }}
+                activeDot={{
+                  r: 7,
+                  strokeWidth: 2,
+                  fill: getPatternColorForChart(selectedBarangayPattern),
+                  stroke: getPatternColorForChart(selectedBarangayPattern),
                 }}
               />
-            )}
-          </LineChart>
-        </ResponsiveContainer>
+            </LineChart>
+          </ResponsiveContainer>
+        )}
       </ChartContainer>
 
-      {/* Custom Legend - Moved outside the chart container */}
-      <div className="flex  flex-wrap  justify-start gap-3 ml-3 ">
+      <div className="flex flex-wrap justify-start gap-3 ml-3 ">
         {patternLevels.map(({ label, color }) => (
           <div key={label} className="flex items-center gap-2">
             <div


### PR DESCRIPTION
Always render trend header and selectors; prevent controls from disappearing When no data (404 or not found or empty), show an empty chart container with message: